### PR TITLE
Implement Streaming Requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -125,7 +125,6 @@ func (c *Client) NewStreamingCompletion(ctx context.Context, req *Request) (<-ch
 						return
 					case eventTypePing:
 						// Do nothing.
-						break
 					default:
 						errCh <- ErrBadEvent
 						return
@@ -155,6 +154,7 @@ const (
 	eventTypePing       eventType = "ping"
 )
 
+// ErrBadEvent is returned when an event is received that cannot be parsed.
 var ErrBadEvent = errors.New("bad event")
 
 type event struct {

--- a/error.go
+++ b/error.go
@@ -1,0 +1,16 @@
+package anthropic
+
+import "fmt"
+
+type errorResponse struct {
+	Err Error `json:"error"`
+}
+
+func (e *errorResponse) Error() string {
+	return fmt.Sprintf("%s: %s", e.Err.Type, e.Err.Message)
+}
+
+type Error struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}

--- a/error.go
+++ b/error.go
@@ -6,10 +6,12 @@ type errorResponse struct {
 	Err Error `json:"error"`
 }
 
+// Error implements the error interface.
 func (e *errorResponse) Error() string {
 	return fmt.Sprintf("%s: %s", e.Err.Type, e.Err.Message)
 }
 
+// Error represents an error returned from the API.
 type Error struct {
 	Type    string `json:"type"`
 	Message string `json:"message"`

--- a/response.go
+++ b/response.go
@@ -5,5 +5,7 @@ type Response struct {
 	// Completion is he resulting completion up to and excluding the stop sequences.
 	Completion string `json:"completion"`
 	// StopReason is the reason Anthropic stopped sampling. It will be one of "stop_sequence" or "max_tokens".
-	StopReason string `json:"stop_reason"`
+	StopReason *string `json:"stop_reason"`
+	// Model is the model that performed the completion.
+	Model Model `json:"model"`
 }


### PR DESCRIPTION
The client now supports making a streaming request, which returns responses on a channel as they come back from the API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fabiustech/anthropic/7)
<!-- Reviewable:end -->
