### PR TITLE
Fix: Prevent Mutation of req Object to Enable Retries using same req object

### DIFF
--- a/bedrock_client.go
+++ b/bedrock_client.go
@@ -29,10 +29,11 @@ func (bc *BedrockClient) Debug() {
 
 // NewCompletion returns a completion response from the API.
 func (bc *BedrockClient) NewCompletion(ctx context.Context, req *Request) (*Response, error) {
-	var m = req.Model
-	req.Model = UnknownModel
+	r := *req
+	var m = r.Model
+	r.Model = UnknownModel
 
-	var b, err = json.Marshal(req)
+	var b, err = json.Marshal(r)
 	if err != nil {
 		return nil, err
 	}
@@ -92,10 +93,11 @@ loop:
 // NewStreamingCompletion returns two channels: the first will be sent |*Response|s as they are received from
 // the API and the second is sent any error(s) encountered while receiving / parsing responses.
 func (bc *BedrockClient) NewStreamingCompletion(ctx context.Context, req *Request) (<-chan *Response, <-chan error, error) {
-	var m = req.Model
-	req.Model = UnknownModel
+	r := *req
+	var m = r.Model
+	r.Model = UnknownModel
 
-	var b, err = json.Marshal(req)
+	var b, err = json.Marshal(r)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### Overview

This PR addresses an issue where the `req` object was being mutated, specifically altering its `Model` field to `UnknownModel` during the JSON Marshalling process.

### Impact

This behavior restricted consumers of the library from reattempting the request using the same `req` object, as its state had been modified. This is particularly problematic for retry logic that waits and attempts to use the original request parameters, such as after encountering a `ThrottlingException`

### Solution

The code has been refactored to avoid mutating the `req` object. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fabiustech/anthropic/13)
<!-- Reviewable:end -->
