### PR TITLE
Return ResponseErrors from batch requests, add status code & Retryable method

### DIFF
--- a/client.go
+++ b/client.go
@@ -152,7 +152,7 @@ func (c *Client) NewStreamingCompletion(ctx context.Context, req *Request) (<-ch
 							return
 						}
 					case eventTypeError:
-						var errResp = &errorResponse{}
+						var errResp = &ResponseError{}
 						if err = json.Unmarshal(e.Data, errResp); err != nil {
 							errCh <- errors.New(string(e.Data))
 							return
@@ -334,7 +334,15 @@ func interpretResponse(resp *http.Response) error {
 		var b, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("code: %d, unable to read response body", resp.StatusCode)
+
 		}
+
+		var errResp = &ResponseError{}
+		if err = json.Unmarshal(b, errResp); err == nil {
+			errResp.Err.Code = resp.StatusCode
+			return errResp
+		}
+
 		return fmt.Errorf("code: %d, error: %s", resp.StatusCode, string(b))
 	}
 

--- a/error.go
+++ b/error.go
@@ -1,18 +1,40 @@
 package anthropic
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
-type errorResponse struct {
+const (
+	errRateLimit  = "rate_limit_error"
+	errOverloaded = "overloaded_error"
+)
+
+type ResponseError struct {
 	Err Error `json:"error"`
 }
 
 // Error implements the error interface.
-func (e *errorResponse) Error() string {
-	return fmt.Sprintf("%s: %s", e.Err.Type, e.Err.Message)
+func (r *ResponseError) Error() string {
+	return fmt.Sprintf("%s: %s (code: %s)", r.Err.Type, r.Err.Message, r.Err.Code)
+}
+
+// Retryable returns true if the error is retryable. For now, we assume all 5xx errors are transient.
+// We also return true on 429, but it's up to the caller to determine the appropriate retry strategy
+// given rate limits are based on # of concurrent requests.
+func (r *ResponseError) Retryable() bool {
+	return r.Err.Code >= http.StatusInternalServerError ||
+		r.Err.Code == http.StatusTooManyRequests ||
+		r.Err.Type == errOverloaded ||
+		r.Err.Type == errRateLimit
 }
 
 // Error represents an error returned from the API.
 type Error struct {
-	Type    string `json:"type"`
+	// Type represents the type of error (e.g. "invalid_request_error").
+	Type string `json:"type"`
+	// Message is a human-readable message about the error.
 	Message string `json:"message"`
+	// Code is the HTTP status code returned by the API (populated by the client).
+	Code int `json:"code"`
 }


### PR DESCRIPTION
This change:
- Exports `ResponseError` (previously `errResponse`)
- Adds a `Code` field to `ResponseError`, which will be populated by the client.
- Adds a `Retryable` method to `ResponseError`
- Now returns `ResponseError` from non-streaming requests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fabiustech/anthropic/14)
<!-- Reviewable:end -->
