### PR TITLE
Added two more options to Tool Use

### DIFF
--- a/v3/tool.go
+++ b/v3/tool.go
@@ -12,6 +12,8 @@ type Schema struct {
 	Type        SchemaType         `json:"type"`
 	Properties  map[string]*Schema `json:"properties,omitempty"`
 	Title       string             `json:"title,omitempty"`
+	Items       *Schema            `json:"items,omitempty"`
+	Enum        []interface{}      `json:"enum,omitempty"`
 	Description string             `json:"description,omitempty"`
 	Required    []string           `json:"required,omitempty"`
 }


### PR DESCRIPTION
The Tool use client is incomplete based on the documentation from Anthropic. It is missing two options:
- Items: These are used when the type is an Array, and allows the user to describe the object of the elements of the array
- Enum: Mainly used for strings and integers, this tells the model what the possible values can be from a specific set of values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fabiustech/anthropic/22)
<!-- Reviewable:end -->
