### PR TITLE
updated tool use to deal with errors

### DIFF
--- a/v3/message.go
+++ b/v3/message.go
@@ -21,7 +21,8 @@ type ShortHandMessage struct {
 
 // MessageContent represents the content of a message.
 type MessageContent struct {
-	// Type is the type of the content. It can be either "text", "image", or "tool_use".
+	// Type is the type of the content. It can be either "text", "image", or "tool_use", or "tool_result"
+	// ("tool_result" is only used when there's an error with the tool usage by the model and the model is being instructed to fix it in a subsequent call).
 	Type string `json:"type"`
 	// Text is the text content of the message. Leave this empty if passing an image.
 	Text string `json:"text,omitempty"`
@@ -33,6 +34,10 @@ type MessageContent struct {
 	Input json.RawMessage `json:"input,omitempty"`
 	// Content is the result of a calling specified tool (if any).
 	Content string `json:"content,omitempty"`
+	// IsError is true only when there is an error with the first tool usage and the model is being instructed to try again.
+	IsError bool `json:"is_error,omitempty"`
+	// ToolUseID is the ID of the tool usage, only used when the model is instructed to try again.
+	ToolUseID string `json:"tool_use_id,omitempty"`
 }
 
 // MediaSource represents the media source of a message.


### PR DESCRIPTION
There are some under-documented options in the anthropic API for tool usage that don't seem to show up in the official API spec but do show up in the documentation for tool usage specifically: https://docs.anthropic.com/en/docs/build-with-claude/tool-use


Added the ability to add the "tool_result" message type, in the case that we want the model to error correct itself on it's tool usage as described in the documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fabiustech/anthropic/23)
<!-- Reviewable:end -->
